### PR TITLE
Disable fail checking, which is useless in a pod

### DIFF
--- a/nginx/proxy_ssl.conf
+++ b/nginx/proxy_ssl.conf
@@ -1,5 +1,7 @@
 upstream target_service {
   server {{TARGET_SERVICE}};
+  # Disable fail checking; we don't have any failover options.
+  max_fails 0
 }
 
 server {


### PR DESCRIPTION
As we only have one upstream, it's pointless to timeout when we
get a failure. Always pass the traffic through to the upstream,
even if there was recently a few error responses.

http://nginx.org/en/docs/http/ngx_http_upstream_module.html#max_fails